### PR TITLE
Reduce number of parallel nodes to 5

### DIFF
--- a/pipelines/etcd.yml
+++ b/pipelines/etcd.yml
@@ -402,7 +402,7 @@ jobs:
     params:
       BBL_STATE_DIR: eats
       ENABLE_TURBULENCE_TESTS: false
-      PARALLEL_NODES: 7
+      PARALLEL_NODES: 5
     on_failure:
       put: slack-alert
       params:


### PR DESCRIPTION
There are 7 workers avaiable on on BOSH director.
1 is used for non-deployment tasks
1 is used for running errand
Only 5 workers are available at the single moment